### PR TITLE
update psycopg2 module to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ djangorestframework==3.9.1
 gunicorn==19.7.1
 pytz==2017.3
 whitenoise==3.3.1
-psycopg2==2.7.3.2
+psycopg2-binary==2.8.4


### PR DESCRIPTION
### pip command related psycoqg2 yields the following error:

``` shell 
pip install -r requirements.txt
```

> ERROR: Failed building wheel for psycopg2



Thus reflected the following change on the [requirements.txt](./requirements.txt) from "psycopg" module to "psycopg2-binary"

The module has the same functionality as psycopg2. [Stackoverflow link is attached for your further reference](https://stackoverflow.com/questions/5420789/how-to-install-psycopg2-with-pip-on-python)

### My Environment
- Mac OS 10.15.3 (Cattalina)
- Python Virtual Environment(pipenv), python version 3.7